### PR TITLE
Improve contrast of numeric constants

### DIFF
--- a/themes/dark_vs.json
+++ b/themes/dark_vs.json
@@ -71,13 +71,18 @@
     },
     {
       "scope": [
-        "constant.numeric",
         "variable.other.enummember",
         "keyword.operator.plus.exponent",
         "keyword.operator.minus.exponent"
       ],
       "settings": {
         "foreground": "#2AACB8"
+      }
+    },
+    {
+      "scope": ["constant.numeric"],
+      "settings": {
+        "foreground": "#DDA52D"
       }
     },
     {


### PR DESCRIPTION
This change makes numeric literals stand out better.

### Before
![code](https://github.com/qvisten12/jetbrains-new-ui-dark-theme/assets/48856190/085aff8f-5fcf-4181-b86a-2c531227bcbd)

### After
![code2](https://github.com/qvisten12/jetbrains-new-ui-dark-theme/assets/48856190/5a0e463e-3798-468d-9e89-dd61c46d6d68)

